### PR TITLE
Fix typos in doc and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use this package, simply add the following code to your document:
     model: "Model A"
   ),
   
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: true,
   clarifications: "Answer the questions in the spaces provided. If you run out of room for an answer, continue on the back of the page."
 )

--- a/doc/g-exam-manual.typ
+++ b/doc/g-exam-manual.typ
@@ -93,9 +93,9 @@ We can indicate a logo of the educational center, a description of the exam, sub
 
 == Student Information
 
-// Para que un encabezado en el que el alumno debe introducir sus datos personales, se ha de especificar en la plantilal mediante la prpiedad `show-studen-data` indicando como se quiere que aparezca este cuadro. 
+// Para que un encabezado en el que el alumno debe introducir sus datos personales, se ha de especificar en la plantilal mediante la prpiedad `show-student-data` indicando como se quiere que aparezca este cuadro. 
 // Los valores pueden ser:
-In order for a header in which the student must enter his/her personal data, it must be specified on the template by means of the 'show-studen-data' property indicating how you want this box to appear. 
+In order for a header in which the student must enter his/her personal data, it must be specified on the template by means of the 'show-student-data' property indicating how you want this box to appear. 
 Values can be:
 - *first-page*: It will only appear on the first page.
 - *odd-pages*: It will appear on odd-numbered pages.
@@ -107,7 +107,7 @@ The following example will display student information on the first page.
 #pad(left: 1em)[
 ```typ-example
 #show: g-exam.with(
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
 )
 ```]
 

--- a/examples/exam-002.typ
+++ b/examples/exam-002.typ
@@ -19,7 +19,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   show-studen-data: "first-page",

--- a/examples/exam-002.typ
+++ b/examples/exam-002.typ
@@ -22,7 +22,7 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: false,
   question-point-position: left,
   clarifications: "Answer the questions in the spaces provided. If you run out of room for an answer, continue on the back of the page."

--- a/examples/exam-003.typ
+++ b/examples/exam-003.typ
@@ -19,7 +19,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   show-studen-data: "first-page",

--- a/examples/exam-003.typ
+++ b/examples/exam-003.typ
@@ -22,7 +22,7 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: false,
   question-point-position: left,
   clarifications: "Answer the questions in the spaces provided. If you run out of room for an answer, continue on the back of the page."

--- a/examples/exam-005.typ
+++ b/examples/exam-005.typ
@@ -19,7 +19,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   show-studen-data: "first-page",

--- a/examples/exam-005.typ
+++ b/examples/exam-005.typ
@@ -22,7 +22,7 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: false,
   question-point-position: right,
   clarifications: "Answer the questions in the spaces provided. If you run out of room for an answer, continue on the back of the page."

--- a/examples/exam-006.typ
+++ b/examples/exam-006.typ
@@ -19,7 +19,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   show-studen-data: "first-page",

--- a/examples/exam-006.typ
+++ b/examples/exam-006.typ
@@ -22,7 +22,7 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: false,
   question-point-position: right,
   // show-solution: false,

--- a/examples/exam-mathematics.typ
+++ b/examples/exam-mathematics.typ
@@ -19,7 +19,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   // show-studen-data: "first-page",

--- a/examples/exam-mathematics.typ
+++ b/examples/exam-mathematics.typ
@@ -22,9 +22,9 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  // show-studen-data: "first-page",
-  show-studen-data: "odd-pages",
-  // show-studen-data: none,
+  // show-student-data: "first-page",
+  show-student-data: "odd-pages",
+  // show-student-data: none,
   show-grade-table: true,
   question-point-position: right,
   clarifications: (

--- a/examples/exam-sugar-notation.typ
+++ b/examples/exam-sugar-notation.typ
@@ -2,7 +2,7 @@
 
 #show: g-exam.with()
 
-#g-question(point:.2)[Pregunta]
+#g-question(point:.2)[Question]
 
 #g-subquestion(point:.2)[sub 3]
 
@@ -28,9 +28,9 @@
 
 =? Solve this ecuation $x^2 -4x +4 = 0$ 
 
-#g-question(point:.2)[ Solve this ecuation $x^2 -4x +4 = 0$ ]
+#g-question(point:.2)[ Solve this equation $x^2 -4x +4 = 0$ ]
 
-=! Solulution of the question.
+=! Solution of the question.
 
 =? 2.4 $x^2 -4x +4 = 0$
 

--- a/examples/exam-table-content.typ
+++ b/examples/exam-table-content.typ
@@ -19,7 +19,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   show-studen-data: "first-page",

--- a/examples/exam-table-content.typ
+++ b/examples/exam-table-content.typ
@@ -22,7 +22,7 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: true,
   question-point-position: left,
   clarifications: "Answer the questions in the spaces provided. If you run out of room for an answer, continue on the back of the page."

--- a/examples/size-text-question.typ
+++ b/examples/size-text-question.typ
@@ -23,7 +23,7 @@
   language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: false,
   question-point-position: right,
   question-text-parameters: (size: 16pt, spacing:200%),

--- a/examples/size-text-question.typ
+++ b/examples/size-text-question.typ
@@ -20,7 +20,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   date: "November 21, 2023",
   show-studen-data: "first-page",

--- a/src/auxiliary.typ
+++ b/src/auxiliary.typ
@@ -124,7 +124,7 @@
 }
 
 #let __read-localization = (
-  languaje: "en",
+  language: "en",
   localization: (
     grade-table-queston: none,
     grade-table-total: none,
@@ -141,7 +141,7 @@
   )) => {
     let __lang_data = toml("./lang.toml")
     if(__lang_data != none) {
-      let __read_lang_data = __lang_data.at(languaje, default: localization)
+      let __read_lang_data = __lang_data.at(language, default: localization)
 
       if(__read_lang_data != none) {
         let __read-localization_value = (read_lang_data: none, field: "", localization: none) => {

--- a/src/g-exam.typ
+++ b/src/g-exam.typ
@@ -7,31 +7,30 @@
 
 /// Template for creating an exam.
 /// 
-/// - autor: Infomation of autor of exam.
+///  - author: Infomation of author of exam.
 ///  - name (string, content): Name of author of exam.
-///  - email (string): e-mail of author of exam.
+///  - email (string): E-mail of author of exam.
 ///  - watermark (string): Watermark with information about the author of the document.
-/// - scholl: Information of scholl.
+///  - school: Information of school.
 ///  - name (string, content): Name of the school or institution generating the exam.
 ///  - logo (none, content, bytes): Logo of the school or institution generating the exam.
-/// - exam-info: Information of exam
-///  - academic-period(none, content, str): academic period.
-///  - academic-level(none, content, str): acadmic level.
-///  - academic-subject(none, content, str): acadmic subname,
-///  - number(none, content, str): Number of exam.
-///  - content(none, content, str): Conten of exam.
-///  - model(none, content, str): Model of exam.
-/// - date (sting): Date of generate document.
-/// - keywords (string): keywords of document.
-/// - languaje (en, es, de, fr, pt, it): Languaje of docuemnt. English, Spanish, German, Portuguese and Italian are defined.
-///     Ejemplo buy bonito:
-/// - clarifications (string, content, array): Clarifications of exam. It will appear in a box on the first page.
-/// - question-text-parameters: Parameter of text in question and subquestion. For example, it allows us to change the text size of the questions.
-/// - show-studen-data(none, true, false, "first-page", "odd-pages"): It shows a box for the student to enter their details. It can appear on the first page or on all odd-numbered pages.
-/// - show-grade-table: (bool): Show grade table.
-/// - decimal-separator: (".", ","): Indicates the decimal separation character.
-/// - question-point-position: (none, left, right): Position of question point.
-/// - show-solution: (true, false): It shows the solutions to the questions.
+///  - exam-info: Information of exam.
+///  - academic-period (none, content, str): Academic period.
+///  - academic-level (none, content, str): Academic level.
+///  - academic-subject (none, content, str): Academic subname.
+///  - number (none, content, str): Number of exam.
+///  - content (none, content, str): Content of exam.
+///  - model (none, content, str): Model of exam.
+///  - date (sting): Date of generate document.
+///  - keywords (string): Keywords of document.
+///  - language (en, es, de, fr, pt, it): Language of document. English, Spanish, German, French, Portuguese and Italian are defined.
+///  - clarifications (string, content, array): Clarifications of exam. It will appear in a box on the first page.
+///  - question-text-parameters: Parameter of text in question and subquestion. For example, it allows us to change the text size of the questions.
+///  - show-student-data (none, true, false, "first-page", "odd-pages"): Show a box for the student to enter their details. It can appear on the first page or on all odd-numbered pages.
+///  - show-grade-table: (bool): Show the grade table.
+///  - decimal-separator: (".", ","): Indicate the decimal separation character.
+///  - question-point-position: (none, left, right): Position of question points.
+///  - show-solution: (true, false): Show the solutions.
 #let g-exam(
   author: (
     name: "",
@@ -50,7 +49,7 @@
     content: none,
     model: none
   ),
-  languaje: "en",
+  language: "en",
   localization: (
     grade-table-queston: none,
     grade-table-total: none,
@@ -69,7 +68,7 @@
   keywords: none,
   clarifications: none,
   question-text-parameters: none,
-  show-studen-data: "first-page",
+  show-student-data: "first-page",
   show-grade-table: true,
   decimal-separator: ".",
   question-point-position: left,
@@ -77,7 +76,7 @@
   body,
 ) = {
   
-  assert(show-studen-data in (none, true, false, "first-page", "odd-pages"),
+  assert(show-student-data in (none, true, false, "first-page", "odd-pages"),
       message: "Invalid show studen data")
 
   assert(question-point-position in (none, left, right),
@@ -147,7 +146,7 @@
                     ],
                   ),
                   line(length: 100%, stroke: 1pt + gray),
-                  if show-studen-data in (true, "first-page", "odd-pages") {
+                  if show-student-data in (true, "first-page", "odd-pages") {
                     __g-student-data()
                   }
               )
@@ -173,7 +172,7 @@
               ]
             )
             line(length: 100%, stroke: 1pt + gray) 
-            if show-studen-data == "odd-pages" {
+            if show-student-data == "odd-pages" {
               __g-student-data(show-line-two: false)
             }
         }
@@ -228,11 +227,11 @@
   set par(justify: true) 
   set text(font: "New Computer Modern")
   
-  __read-localization(languaje: languaje, localization: localization)
+  __read-localization(language: language, localization: localization)
   __g-question-point-position-state.update(u => question-point-position)
   __g-question-text-parameters-state.update(question-text-parameters)
 
-  set text(lang:languaje)
+  set text(lang:language)
 
   if show-grade-table == true {
     __g-grade-table-header(

--- a/template/1er exam.typ
+++ b/template/1er exam.typ
@@ -14,7 +14,7 @@
     model: "Model A"
   ),
   
-  languaje: "en",
+  language: "en",
   decimal-separator: ",",
   show-grade-table: true,
   question-point-position: left,


### PR DESCRIPTION
In the code, only `languaje` -> `language` and `show-studen-data` -> `show-student-data` changed. PDFs have not been updated in consequence.